### PR TITLE
feat: ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ on:
   pull_request:
     branches: ['main']
     types: [opened, synchronize, reopened]
+
 jobs:
   project-build-test:
-    uses: asimov-platform/.github/.github/workflows/npm-ci.yml@v1.0
+    uses: asimov-platform/.github/.github/workflows/npm-ci.yml@master
     with:
       skip-tests: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow configuration for continuous integration (CI). The workflow is designed to trigger on specific events and delegate the build and test process to a reusable workflow.

### New CI workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R14): Added a new workflow named `CI` that triggers on `push` and `pull_request` events for the `main` branch. The workflow uses a reusable workflow (`npm-ci.yml`) from the `asimov-platform` GitHub repository, with the `skip-tests` option set to `true`.
