### PR TITLE
chore: update link to docs

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ export const githubUrl = 'https://github.com/asimov-platform';
 export const modulesUrl = 'https://github.com/asimov-modules';
 export const protocolUrl = 'https://www.asimovprotocol.org';
 export const asimovCLIUrl = 'https://github.com/asimov-platform/asimov-module-cli';
+export const docsUrl = 'https://asimov-specs.github.io/';
 
 export const footerLinks: {
 	title: string;
@@ -21,7 +22,7 @@ export const footerLinks: {
 		links: [
 			{ text: 'CLI Tool', href: asimovCLIUrl, target: '_blank' },
 			{ text: 'Browse Modules', href: modulesUrl, target: '_blank' },
-			{ text: 'Documentation', href: `${asimovCLIUrl}#readme`, target: '_blank' }
+			{ text: 'Documentation', href: docsUrl, target: '_blank' }
 		]
 	},
 	{


### PR DESCRIPTION
This pull request updates the `src/lib/config.ts` file to improve the handling of documentation links. The changes introduce a dedicated `docsUrl` constant and update the `footerLinks` configuration to use this new constant instead of a hardcoded URL.

### Updates to documentation links:

* [`src/lib/config.ts`](diffhunk://#diff-0b4f5977a52cef50ed20e7cdf9761795df9ee1cb3b5e5ea45edeb9394e8a47ffR6): Added a new constant `docsUrl` with the URL `'https://asimov-specs.github.io/'` to centralize the documentation link.
* [`src/lib/config.ts`](diffhunk://#diff-0b4f5977a52cef50ed20e7cdf9761795df9ee1cb3b5e5ea45edeb9394e8a47ffL24-R25): Updated the `footerLinks` configuration to use the `docsUrl` constant for the "Documentation" link, replacing the previous hardcoded URL.