### PR TITLE
chore: display daily metrics instead of total

### DIFF
--- a/src/components/common/DownloadStats.svelte
+++ b/src/components/common/DownloadStats.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { createQuery } from '@tanstack/svelte-query';
 	import Download from 'phosphor-svelte/lib/Download';
-	import { fetchDownloadsStats, formatDownloads } from '../../lib/downloads';
+	import {
+		fetchDailyDownloadsStats,
+		getTotalDownloadsFromTimeline,
+		formatDownloads
+	} from '../../lib/downloads';
 
 	interface Props {
 		variant?: 'desktop' | 'mobile';
@@ -10,12 +14,16 @@
 	let { variant = 'desktop' }: Props = $props();
 
 	const downloadsQuery = createQuery({
-		queryKey: ['downloads-stats'],
-		queryFn: fetchDownloadsStats,
+		queryKey: ['daily-download-stats'],
+		queryFn: fetchDailyDownloadsStats,
 		staleTime: 30 * 60 * 1000,
 		gcTime: 60 * 60 * 1000,
 		retry: 2
 	});
+
+	const totalDownloads = $derived(
+		$downloadsQuery.data ? getTotalDownloadsFromTimeline($downloadsQuery.data) : 0
+	);
 
 	const badgeClass =
 		variant === 'desktop'
@@ -29,10 +37,10 @@
 </script>
 
 {#if $downloadsQuery.data}
-	<div class={badgeClass}>
+	<div class={badgeClass} title="Total daily downloads across all platforms">
 		<Download size={14} class="text-gray-500" />
 		<span class="font-medium text-gray-700">
-			{formatDownloads($downloadsQuery.data.totalDownloads)}
+			{formatDownloads(totalDownloads)}
 		</span>
 	</div>
 {:else if $downloadsQuery.isLoading}

--- a/src/components/common/PlatformDownloadsChart.svelte
+++ b/src/components/common/PlatformDownloadsChart.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import { Chart } from 'svelte-echarts';
+	import { init, use } from 'echarts/core';
+
+	import { LineChart, BarChart } from 'echarts/charts';
+	import {
+		TitleComponent,
+		TooltipComponent,
+		GridComponent,
+		DatasetComponent,
+		TransformComponent,
+		LegendComponent
+	} from 'echarts/components';
+	import { LabelLayout, UniversalTransition } from 'echarts/features';
+	import { CanvasRenderer } from 'echarts/renderers';
+
+	use([
+		LineChart,
+		BarChart,
+		TitleComponent,
+		TooltipComponent,
+		GridComponent,
+		DatasetComponent,
+		TransformComponent,
+		LegendComponent,
+		LabelLayout,
+		UniversalTransition,
+		CanvasRenderer
+	]);
+
+	export let data: Record<string, Array<{ date: string; count: number }>> | undefined = undefined;
+
+	const seriesColors = {
+		crates: '#ff6b35',
+		rubygems: '#cc342d',
+		npm: '#cb3837',
+		pypi: '#3776ab',
+		github: '#24292e'
+	} as const;
+
+	$: hasTimelineData = data && Object.keys(data).length > 0;
+	$: options = hasTimelineData ? getTimelineChartOptions(data || {}) : getNoDataOptions();
+
+	function getTimelineChartOptions(
+		groupedData: Record<string, Array<{ date: string; count: number }>>
+	) {
+		const allDates = [
+			...new Set(
+				Object.values(groupedData)
+					.flat()
+					.map((item) => item.date)
+			)
+		].sort();
+
+		const xAxisData = allDates.map((date) =>
+			new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+		);
+
+		const series = Object.entries(groupedData).map(([platform, platformData]) => {
+			const data = allDates.map((date) => {
+				const found = platformData.find((item) => item.date === date);
+				return found ? found.count : 0;
+			});
+
+			return {
+				name: platform.charAt(0).toUpperCase() + platform.slice(1),
+				type: 'line' as const,
+				smooth: true,
+				itemStyle: {
+					color: seriesColors[platform as keyof typeof seriesColors] || '#666'
+				},
+				areaStyle: { opacity: 0.3 },
+				data
+			};
+		});
+
+		return {
+			title: {
+				text: 'Daily Downloads by Platform',
+				left: 'center',
+				textStyle: { fontSize: 16 }
+			},
+			grid: {
+				left: '3%',
+				right: '4%',
+				bottom: '3%',
+				top: '15%',
+				containLabel: true
+			},
+			legend: {
+				data: Object.keys(groupedData).map((p) => p.charAt(0).toUpperCase() + p.slice(1)),
+				top: '8%'
+			},
+			tooltip: {
+				trigger: 'axis' as const,
+				backgroundColor: 'rgba(255, 255, 255, 0.95)',
+				borderColor: '#e5e7eb',
+				borderWidth: 1,
+				textStyle: { color: '#374151' }
+			},
+			xAxis: {
+				type: 'category' as const,
+				boundaryGap: false,
+				data: xAxisData
+			},
+			yAxis: {
+				type: 'value' as const,
+				name: 'Downloads'
+			},
+			series
+		};
+	}
+
+	function getNoDataOptions() {
+		return {
+			title: {
+				text: 'No data available',
+				left: 'center',
+				textStyle: { fontSize: 16, color: '#666' }
+			}
+		};
+	}
+</script>
+
+<div class="h-96 w-full">
+	<Chart {init} {options} />
+</div>

--- a/src/components/sections/DailyDownloads.svelte
+++ b/src/components/sections/DailyDownloads.svelte
@@ -1,220 +1,18 @@
 <script lang="ts">
 	import { createQuery } from '@tanstack/svelte-query';
-	import { Chart } from 'svelte-echarts';
-	import { init, use } from 'echarts/core';
-	import { fetchDailyDownloadsStats, fetchDownloadsStats } from '../../lib/downloads';
-	import type { DailyDownloadData, DownloadsStats } from '../../lib/types';
-
-	import { LineChart, BarChart } from 'echarts/charts';
-	import {
-		TitleComponent,
-		TooltipComponent,
-		GridComponent,
-		DatasetComponent,
-		TransformComponent,
-		LegendComponent
-	} from 'echarts/components';
-	import { LabelLayout, UniversalTransition } from 'echarts/features';
-	import { CanvasRenderer } from 'echarts/renderers';
-
-	use([
-		LineChart,
-		BarChart,
-		TitleComponent,
-		TooltipComponent,
-		GridComponent,
-		DatasetComponent,
-		TransformComponent,
-		LegendComponent,
-		LabelLayout,
-		UniversalTransition,
-		CanvasRenderer
-	]);
+	import { fetchDailyDownloadsStats } from '../../lib/downloads';
+	import PlatformDownloadsChart from '../common/PlatformDownloadsChart.svelte';
 
 	const dailyDownloadsQuery = createQuery({
-		queryKey: ['daily-downloads'],
+		queryKey: ['daily-download-stats'],
 		queryFn: fetchDailyDownloadsStats,
 		staleTime: 30 * 60 * 1000,
 		gcTime: 60 * 60 * 1000,
 		retry: 2
 	});
 
-	const downloadsStatsQuery = createQuery({
-		queryKey: ['downloads-stats'],
-		queryFn: fetchDownloadsStats,
-		staleTime: 30 * 60 * 1000,
-		gcTime: 60 * 60 * 1000,
-		retry: 2
-	});
-
-	const seriesColors = {
-		crates: '#ff6b35',
-		rubygems: '#cc342d',
-		npm: '#cb3837',
-		pypi: '#3776ab'
-	} as const;
-
-	interface GroupedDownloadData {
-		date: Date;
-		crates: number;
-		rubygems: number;
-		npm: number;
-		pypi: number;
-	}
-
-	$: hasTimelineData = $dailyDownloadsQuery.data && $dailyDownloadsQuery.data.length > 0;
-	$: options = hasTimelineData
-		? getTimelineChartOptions($dailyDownloadsQuery.data || [])
-		: getBarChartOptions($downloadsStatsQuery.data);
-
-	function getTimelineChartOptions(data: DailyDownloadData[]) {
-		const groupedByDate = data.reduce(
-			(acc, item) => {
-				if (!acc[item.date]) {
-					acc[item.date] = {
-						date: new Date(item.date),
-						crates: 0,
-						rubygems: 0,
-						npm: 0,
-						pypi: 0
-					};
-				}
-				acc[item.date][item.source as keyof Omit<GroupedDownloadData, 'date'>] = item.downloads;
-				return acc;
-			},
-			{} as Record<string, GroupedDownloadData>
-		);
-
-		const sortedData = Object.values(groupedByDate).sort(
-			(a, b) => a.date.getTime() - b.date.getTime()
-		);
-
-		const xAxisData = sortedData.map((d) =>
-			d.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-		);
-
-		return {
-			title: {
-				text: 'Downloads by Platform Over Time',
-				left: 'center',
-				textStyle: { fontSize: 16 }
-			},
-			grid: {
-				left: '3%',
-				right: '4%',
-				bottom: '3%',
-				top: '15%',
-				containLabel: true
-			},
-			legend: {
-				data: ['Crates', 'RubyGems', 'NPM', 'PyPI'],
-				top: '8%'
-			},
-			tooltip: {
-				trigger: 'axis' as const,
-				backgroundColor: 'rgba(255, 255, 255, 0.95)',
-				borderColor: '#e5e7eb',
-				borderWidth: 1,
-				textStyle: { color: '#374151' }
-			},
-			xAxis: {
-				type: 'category' as const,
-				boundaryGap: false,
-				data: xAxisData
-			},
-			yAxis: {
-				type: 'value' as const,
-				name: 'Downloads'
-			},
-			series: [
-				{
-					name: 'Crates',
-					type: 'line' as const,
-					smooth: true,
-					itemStyle: { color: seriesColors.crates },
-					areaStyle: { opacity: 0.3 },
-					data: sortedData.map((d) => d.crates)
-				},
-				{
-					name: 'RubyGems',
-					type: 'line' as const,
-					smooth: true,
-					itemStyle: { color: seriesColors.rubygems },
-					areaStyle: { opacity: 0.3 },
-					data: sortedData.map((d) => d.rubygems)
-				},
-				{
-					name: 'NPM',
-					type: 'line' as const,
-					smooth: true,
-					itemStyle: { color: seriesColors.npm },
-					areaStyle: { opacity: 0.3 },
-					data: sortedData.map((d) => d.npm)
-				},
-				{
-					name: 'PyPI',
-					type: 'line' as const,
-					smooth: true,
-					itemStyle: { color: seriesColors.pypi },
-					areaStyle: { opacity: 0.3 },
-					data: sortedData.map((d) => d.pypi)
-				}
-			]
-		};
-	}
-
-	function getBarChartOptions(statsData: DownloadsStats | undefined) {
-		if (!statsData || !statsData.bySource) {
-			return { title: { text: 'No data available' } };
-		}
-
-		const platforms = Object.keys(statsData.bySource);
-		const downloads = Object.values(statsData.bySource);
-		const colors = platforms.map(
-			(platform) => seriesColors[platform as keyof typeof seriesColors] || '#666'
-		);
-
-		return {
-			title: {
-				text: 'Total Downloads by Platform',
-				left: 'center',
-				textStyle: { fontSize: 16 }
-			},
-			grid: {
-				left: '3%',
-				right: '4%',
-				bottom: '3%',
-				top: '15%',
-				containLabel: true
-			},
-			tooltip: {
-				trigger: 'item' as const,
-				backgroundColor: 'rgba(255, 255, 255, 0.95)',
-				borderColor: '#e5e7eb',
-				borderWidth: 1,
-				textStyle: { color: '#374151' },
-				formatter: '{b}: {c} downloads'
-			},
-			xAxis: {
-				type: 'category' as const,
-				data: platforms.map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-			},
-			yAxis: {
-				type: 'value' as const,
-				name: 'Total Downloads'
-			},
-			series: [
-				{
-					type: 'bar' as const,
-					data: downloads.map((value, index) => ({
-						value,
-						itemStyle: { color: colors[index] }
-					})),
-					barWidth: '60%'
-				}
-			]
-		};
-	}
+	$: hasTimelineData =
+		$dailyDownloadsQuery.data && Object.keys($dailyDownloadsQuery.data).length > 0;
 </script>
 
 <section id="daily-downloads" class="py-20">
@@ -230,7 +28,7 @@
 
 		<div class="mx-auto max-w-6xl">
 			<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-				{#if $dailyDownloadsQuery.isLoading || $downloadsStatsQuery.isLoading}
+				{#if $dailyDownloadsQuery.isLoading}
 					<div class="flex h-96 items-center justify-center">
 						<div class="text-center">
 							<div
@@ -240,18 +38,9 @@
 						</div>
 					</div>
 				{:else}
-					<div class="chart-container">
-						<Chart {init} {options} />
-					</div>
+					<PlatformDownloadsChart data={$dailyDownloadsQuery.data} />
 				{/if}
 			</div>
 		</div>
 	</div>
 </section>
-
-<style>
-	.chart-container {
-		width: 100%;
-		height: 400px;
-	}
-</style>

--- a/src/lib/downloads.ts
+++ b/src/lib/downloads.ts
@@ -1,10 +1,12 @@
 import { ZUPLO_API_URL } from './config';
-import type { DownloadData, DownloadsStats, DailyDownloadData } from './types';
+import type { DownloadData } from './types';
 
-export async function fetchDownloadsStats(): Promise<DownloadsStats> {
+export async function fetchDailyDownloadsStats(): Promise<
+	Record<string, Array<{ date: string; count: number }>>
+> {
 	try {
 		const isDev = import.meta.env.DEV;
-		const apiUrl = isDev ? '/api/downloads' : `${ZUPLO_API_URL}/downloads`;
+		const apiUrl = isDev ? `/api/downloads` : `${ZUPLO_API_URL}/downloads`;
 
 		const response = await fetch(apiUrl, {
 			method: 'GET',
@@ -14,231 +16,78 @@ export async function fetchDownloadsStats(): Promise<DownloadsStats> {
 		});
 
 		if (!response.ok) {
-			throw new Error(`Failed to fetch downloads: ${response.status}`);
+			throw new Error(`Failed to fetch downloads data: ${response.status}`);
 		}
 
-		const data: DownloadData[] = await response.json();
-
-		const latestDate = getLatestDate(data);
-		const latestData = data.filter((item) => item.collected_at === latestDate);
-
-		const totalDownloads = latestData.reduce((sum, item) => sum + item.downloads, 0);
-		const uniqueModules = new Set(latestData.map((item) => item.name));
-		const totalModules = uniqueModules.size;
-
-		const bySource = latestData.reduce(
-			(acc, item) => {
-				acc[item.source] = (acc[item.source] || 0) + item.downloads;
-				return acc;
-			},
-			{} as Record<string, number>
-		);
-
-		return {
-			totalDownloads,
-			totalModules,
-			bySource
-		};
-	} catch (error) {
-		console.error('Error fetching downloads stats:', error);
-		return getMockDataStats();
-	}
-}
-
-export async function fetchDailyDownloadsStats(): Promise<DailyDownloadData[]> {
-	try {
-		const isDev = import.meta.env.DEV;
-
-		const dates = getLast30Days();
-		const allData: DownloadData[] = [];
-
-		// Fetch data for each date
-		const fetchPromises = dates.map((date) => {
-			const apiUrl = isDev
-				? `/api/downloads?collected_at=eq.${date}`
-				: `${ZUPLO_API_URL}/downloads?collected_at=eq.${date}`;
-
-			return fetch(apiUrl, {
-				method: 'GET',
-				headers: {
-					'Content-Type': 'application/json'
-				}
-			})
-				.then((response) => {
-					if (response.ok) {
-						return response.json();
-					} else {
-						throw new Error(`Failed to fetch data for ${date}: ${response.status}`);
-					}
-				})
-				.catch((dateError) => {
-					console.warn(`Failed to fetch data for ${date}:`, dateError);
-					return [];
-				});
-		});
-
-		const results = await Promise.allSettled(fetchPromises);
-		results.forEach((result) => {
-			if (result.status === 'fulfilled') {
-				allData.push(...result.value);
-			}
-		});
+		const allData: DownloadData[] = await response.json();
 
 		if (allData.length === 0) {
-			console.log('No daily data available, returning empty array');
-			return [];
+			console.log('No downloads data available, returning empty object');
+			return {};
 		}
 
-		return processDownloadsByPlatform(allData);
+		const last30DaysData = filterLast30Days(allData);
+
+		return processDailyDownloadsByPlatform(last30DaysData);
 	} catch (error) {
 		console.error('Error fetching daily downloads stats:', error);
-		return [];
+		return {};
 	}
 }
 
-function getLast30Days(): string[] {
-	const dates: string[] = [];
+function filterLast30Days(data: DownloadData[]): DownloadData[] {
 	const today = new Date();
+	const thirtyDaysAgo = new Date(today);
+	thirtyDaysAgo.setDate(today.getDate() - 29);
 
-	for (let i = 29; i >= 0; i--) {
-		const date = new Date(today);
-		date.setDate(today.getDate() - i);
-		dates.push(date.toISOString().split('T')[0]);
-	}
-
-	return dates;
+	return data.filter((item) => {
+		const itemDate = new Date(item.collected_at);
+		return itemDate >= thirtyDaysAgo && itemDate <= today;
+	});
 }
 
-function getLatestDate(data: DownloadData[]): string {
-	if (data.length === 0) return new Date().toISOString().split('T')[0];
+function processDailyDownloadsByPlatform(
+	data: DownloadData[]
+): Record<string, Array<{ date: string; count: number }>> {
+	const platforms = [...new Set(data.map((item) => item.source))];
+	const result: Record<string, Array<{ date: string; count: number }>> = {};
 
-	const dates = data.map((item) => item.collected_at);
-	return dates.sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
-}
+	platforms.forEach((platform) => {
+		result[platform] = [];
+	});
 
-function processDownloadsByPlatform(data: DownloadData[]): DailyDownloadData[] {
 	const groupedByPlatformAndDate = data.reduce(
 		(acc, item) => {
-			const dateKey = item.collected_at;
 			const platform = item.source;
-			const key = `${platform}-${dateKey}`;
+			const date = item.collected_at;
+			const key = `${item.source}-${date}`;
 
 			if (!acc[key]) {
 				acc[key] = {
-					source: platform,
-					date: dateKey,
-					downloads: 0
+					platform,
+					date,
+					dailyDownloads: 0
 				};
 			}
 
-			acc[key].downloads += item.downloads;
-
+			acc[key].dailyDownloads += item.daily_downloads;
 			return acc;
 		},
-		{} as Record<string, DailyDownloadData>
+		{} as Record<string, { platform: string; date: string; dailyDownloads: number }>
 	);
 
-	const result = Object.values(groupedByPlatformAndDate).sort(
-		(a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-	);
+	Object.values(groupedByPlatformAndDate).forEach((item) => {
+		result[item.platform].push({
+			date: item.date,
+			count: item.dailyDownloads
+		});
+	});
+
+	Object.keys(result).forEach((platform) => {
+		result[platform].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+	});
+
 	return result;
-}
-
-function getMockDataStats(): DownloadsStats {
-	const data = getMockData();
-	const totalDownloads = data.reduce((sum, item) => sum + item.downloads, 0);
-	const uniqueModules = new Set(data.map((item) => item.name));
-	const totalModules = uniqueModules.size;
-	const bySource = data.reduce(
-		(acc, item) => {
-			acc[item.source] = (acc[item.source] || 0) + item.downloads;
-			return acc;
-		},
-		{} as Record<string, number>
-	);
-
-	return {
-		totalDownloads,
-		totalModules,
-		bySource
-	};
-}
-
-function getMockData(): DownloadData[] {
-	return [
-		{
-			id: 1,
-			source: 'crates',
-			owner: 'asimov-modules',
-			name: 'asimov-apify-module',
-			downloads: 80,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 2,
-			source: 'crates',
-			owner: 'asimov-modules',
-			name: 'asimov-apple-module',
-			downloads: 70,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 3,
-			source: 'crates',
-			owner: 'asimov-modules',
-			name: 'asimov-brightdata-module',
-			downloads: 60,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 4,
-			source: 'crates',
-			owner: 'asimov-modules',
-			name: 'asimov-clock-module',
-			downloads: 50,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 5,
-			source: 'crates',
-			owner: 'asimov-modules',
-			name: 'asimov-file-module',
-			downloads: 40,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 50,
-			source: 'crates',
-			owner: 'asimov-platform',
-			name: 'asimov-sdk',
-			downloads: 30,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 52,
-			source: 'crates',
-			owner: 'asimov-platform',
-			name: 'asimov-sys',
-			downloads: 20,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		},
-		{
-			id: 158,
-			source: 'rubygems',
-			owner: 'asimov-platform',
-			name: 'asimov.rb',
-			downloads: 10,
-			daily_downloads: 0,
-			collected_at: '2025-06-24'
-		}
-	];
 }
 
 export function formatDownloads(downloads: number): string {
@@ -249,4 +98,21 @@ export function formatDownloads(downloads: number): string {
 		return (downloads / 1000).toFixed(1) + 'K';
 	}
 	return downloads.toLocaleString();
+}
+
+export function getTotalDownloadsFromTimeline(
+	timelineData: Record<string, Array<{ date: string; count: number }>>
+): number {
+	let total = 0;
+
+	Object.values(timelineData).forEach((platformData) => {
+		if (platformData.length > 0) {
+			const sortedData = platformData.sort(
+				(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+			);
+			total += sortedData[0].count;
+		}
+	});
+
+	return total;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,12 +42,6 @@ export interface DownloadData {
 	collected_at: string;
 }
 
-export interface DailyDownloadData {
-	source: string;
-	date: string;
-	downloads: number;
-}
-
 export interface DownloadsStats {
 	totalDownloads: number;
 	totalModules: number;


### PR DESCRIPTION
This pull request introduces significant changes to the download statistics functionality, including enhancements to the data processing logic, updates to components, and the addition of a new chart component. The most important changes involve replacing the previous downloads stats logic with daily downloads stats, introducing a reusable chart component, and simplifying the codebase by removing redundant logic.

### Enhancements to data processing:

* [`src/lib/downloads.ts`](diffhunk://#diff-9f8d779488ace577fd61b6316562eaba6f924b1dfdca485535e9c79994bfadd3L2-L55): Replaced the `fetchDownloadsStats` function with `fetchDailyDownloadsStats`, which now processes daily downloads grouped by platform and date. Added a new helper function, `getTotalDownloadsFromTimeline`, to calculate the total downloads from the timeline data. Removed unused mock data and related functions. [[1]](diffhunk://#diff-9f8d779488ace577fd61b6316562eaba6f924b1dfdca485535e9c79994bfadd3L2-L55) [[2]](diffhunk://#diff-9f8d779488ace577fd61b6316562eaba6f924b1dfdca485535e9c79994bfadd3L89-R54) [[3]](diffhunk://#diff-9f8d779488ace577fd61b6316562eaba6f924b1dfdca485535e9c79994bfadd3L112-R112) [[4]](diffhunk://#diff-9f8d779488ace577fd61b6316562eaba6f924b1dfdca485535e9c79994bfadd3R124-R140)

### Updates to components:

* [`src/components/common/DownloadStats.svelte`](diffhunk://#diff-fb93ef13dbabdd381b3ce799511516112742826f4d6dc4432c5e925c26d8e707L4-R8): Updated the downloads query to use daily downloads stats and introduced derived data for calculating total downloads. Adjusted the display logic to use the new `totalDownloads` variable. [[1]](diffhunk://#diff-fb93ef13dbabdd381b3ce799511516112742826f4d6dc4432c5e925c26d8e707L4-R8) [[2]](diffhunk://#diff-fb93ef13dbabdd381b3ce799511516112742826f4d6dc4432c5e925c26d8e707L13-R27) [[3]](diffhunk://#diff-fb93ef13dbabdd381b3ce799511516112742826f4d6dc4432c5e925c26d8e707L35-R43)
* [`src/components/sections/DailyDownloads.svelte`](diffhunk://#diff-f59647e6469279de9882260930e05e79e9edbb15b4a624e04025feb68a032626L3-R15): Replaced inline chart logic with the new `PlatformDownloadsChart` component. Simplified the query logic to focus on daily downloads stats. Removed redundant chart-related code and styles. [[1]](diffhunk://#diff-f59647e6469279de9882260930e05e79e9edbb15b4a624e04025feb68a032626L3-R15) [[2]](diffhunk://#diff-f59647e6469279de9882260930e05e79e9edbb15b4a624e04025feb68a032626L233-R31) [[3]](diffhunk://#diff-f59647e6469279de9882260930e05e79e9edbb15b4a624e04025feb68a032626L243-L257)

### Addition of reusable chart component:

* [`src/components/common/PlatformDownloadsChart.svelte`](diffhunk://#diff-f9201f75324d14de034a83988eb1f5d3c8a89c2a3d9769431769219cac1bd99bR1-R127): Added a new reusable chart component for visualizing downloads by platform over time. This component handles both timeline data and scenarios where no data is available.

### Simplification of types:

* [`src/lib/types.ts`](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5L45-L50): Removed the `DailyDownloadData` interface as it is no longer needed, simplifying the type definitions.