### PR TITLE
fix: use specific top repo

### DIFF
--- a/src/components/common/GitHubStats.svelte
+++ b/src/components/common/GitHubStats.svelte
@@ -4,6 +4,7 @@
 	import Users from 'phosphor-svelte/lib/Users';
 	import { fetchGitHubStats, formatStars } from '../../lib/github';
 	import { githubUrl } from '../../lib/config';
+	import type { Module } from '../../lib/types';
 
 	interface Props {
 		variant?: 'desktop' | 'mobile';
@@ -45,21 +46,43 @@
 
 {#if $githubStatsQuery.data}
 	<div class={containerClass}>
-		{#if $githubStatsQuery.data.topRepo}
+		{#if $githubStatsQuery.data.repositories}
+			{@const asimovRsRepo = $githubStatsQuery.data.repositories.find(
+				(repo: Module) => repo.name === 'asimov.rs'
+			)}
+			{#if asimovRsRepo}
+				<a
+					href={asimovRsRepo.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class={linkClass}
+					title={asimovRsRepo.name}
+				>
+					<Star size={14} class={iconClass} />
+					<span class={textClass}>
+						{formatStars(asimovRsRepo.stars)}
+					</span>
+				</a>
+			{:else}
+				<a
+					href="https://github.com/asimov-platform/asimov.rs"
+					target="_blank"
+					rel="noopener noreferrer"
+					class={linkClass}
+				>
+					<Star size={14} class={iconClass} />
+					<span class={textClass}>
+						{formatStars($githubStatsQuery.data.stars)}
+					</span>
+				</a>
+			{/if}
+		{:else}
 			<a
-				href={$githubStatsQuery.data.topRepo.url}
+				href="https://github.com/asimov-platform/asimov.rs"
 				target="_blank"
 				rel="noopener noreferrer"
 				class={linkClass}
-				title={$githubStatsQuery.data.topRepo.name}
 			>
-				<Star size={14} class={iconClass} />
-				<span class={textClass}>
-					{formatStars($githubStatsQuery.data.topRepo.stars)}
-				</span>
-			</a>
-		{:else}
-			<a href="{githubUrl}/asimov.rs" target="_blank" rel="noopener noreferrer" class={linkClass}>
 				<Star size={14} class={iconClass} />
 				<span class={textClass}>
 					{formatStars($githubStatsQuery.data.stars)}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -65,13 +65,15 @@ export async function fetchGitHubStats(): Promise<GitHubStats> {
 						description: topRepo.description || 'No description available',
 						stars: topRepo.stars,
 						url: topRepo.url,
-						language: topRepo.language || 'Unknown'
+						language: topRepo.language || 'Unknown',
+						topics: topRepo.topics || []
 					}
-				: undefined
+				: undefined,
+			repositories: data.repositories
 		};
 	} catch (err) {
 		console.error('Failed to fetch GitHub stats:', err);
-		return { stars: 0, followers: 0 };
+		return { stars: 0, followers: 0, topRepo: undefined, repositories: [] };
 	}
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface Module {
 	url: string;
 	language: string;
 	topics: string[];
+	manifestYAML?: string;
 }
 
 export interface AsimovManifest {
@@ -51,27 +52,13 @@ export interface DownloadsStats {
 export interface GitHubStats {
 	stars: number;
 	followers: number;
-	topRepo?: {
-		name: string;
-		description: string;
-		stars: number;
-		url: string;
-		language: string;
-	};
+	topRepo?: Module;
+	repositories: Module[];
 }
 
 export interface ApiMetricsResponse {
 	fetchedAt: string;
 	orgFollowers: number;
 	totalStars: number;
-	repositories: {
-		name: string;
-		description: string | null;
-		stars: number;
-		starsPretty: string;
-		url: string;
-		language: string;
-		topics: string[];
-		manifestYAML?: string;
-	}[];
+	repositories: Module[];
 }


### PR DESCRIPTION
This pull request refactors the GitHub stats functionality in the `src` directory to improve data handling and enhance the user interface. The changes focus on replacing the `topRepo` structure with a more generic `Module` interface, adding support for repository topics and manifest YAML, and updating the UI logic for displaying repository information.

### Refactoring GitHub data structures:

* [`src/lib/types.ts`](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R17): Replaced the `topRepo` structure in `GitHubStats` with the `Module` interface, making it more generic and reusable. Added a `manifestYAML` property to the `Module` interface to support additional metadata. [[1]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R17) [[2]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5L54-R63)

* [`src/lib/github.ts`](diffhunk://#diff-1694b20d1194df7e39a31c079e2ecf60319839b84d39cba2a5b2e765321960b8L68-R76): Updated the `fetchGitHubStats` function to include a `repositories` array in the returned data and added support for repository topics. Modified the fallback values for errors to align with the new structure.

### Enhancements to GitHub stats UI:

* [`src/components/common/GitHubStats.svelte`](diffhunk://#diff-b751087500b05333ffd246c32fb5e646c4a4b1c34e188f3c58ec61f370eb7694L48-R85): Refactored the logic to display repository information by replacing `topRepo` with the `repositories` array. Added logic to find and display stats for the `asimov.rs` repository dynamically, with a fallback to a hardcoded URL if the repository is not found.

* [`src/components/common/GitHubStats.svelte`](diffhunk://#diff-b751087500b05333ffd246c32fb5e646c4a4b1c34e188f3c58ec61f370eb7694R7): Introduced type import for `Module` to improve type safety and consistency.